### PR TITLE
fixes #2: 'Nested ScaleTap widget animates both ScaleTap widgets'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* fixes #2: 'Nested ScaleTap widget animates both ScaleTap widgets' - 19/09/2022
+
 ## [1.0.5] - 04/06/2021
 * Null safety
 

--- a/lib/flutter_scale_tap.dart
+++ b/lib/flutter_scale_tap.dart
@@ -6,7 +6,8 @@ import 'package:flutter/widgets.dart';
 
 const double _DEFAULT_SCALE_MIN_VALUE = 0.95;
 const double _DEFAULT_OPACITY_MIN_VALUE = 0.90;
-final Curve _DEFAULT_SCALE_CURVE = CurveSpring(); // ignore: non_constant_identifier_names
+// ignore: non_constant_identifier_names
+final Curve _DEFAULT_SCALE_CURVE = CurveSpring();
 const Curve _DEFAULT_OPACITY_CURVE = Curves.ease;
 const Duration _DEFAULT_DURATION = Duration(milliseconds: 300);
 
@@ -18,7 +19,20 @@ class ScaleTapConfig {
   static Duration? duration;
 }
 
+class ScaleTapInfo {
+  ScaleTapInfo({
+    required this.tag,
+    this.consumed = false,
+  });
+
+  final String tag;
+  bool consumed;
+
+  static final _default = ScaleTapInfo(tag: "default");
+}
+
 class ScaleTap extends StatefulWidget {
+  final ScaleTapInfo? info;
   final Function()? onPressed;
   final Function()? onLongPress;
   final Widget? child;
@@ -29,7 +43,9 @@ class ScaleTap extends StatefulWidget {
   final double? opacityMinValue;
   final bool enableFeedback;
 
-  ScaleTap({
+  const ScaleTap({
+    Key? key,
+    this.info,
     this.enableFeedback = true,
     this.onPressed,
     this.onLongPress,
@@ -39,16 +55,18 @@ class ScaleTap extends StatefulWidget {
     this.opacityMinValue,
     this.scaleCurve,
     this.opacityCurve,
-  });
+  }) : super(key: key);
 
   @override
-  _ScaleTapState createState() => _ScaleTapState();
+  State<ScaleTap> createState() => _ScaleTapState();
 }
 
 class _ScaleTapState extends State<ScaleTap> with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<double> _scale;
   late Animation<double> _opacity;
+
+  ScaleTapInfo get _info => widget.info ?? ScaleTapInfo._default;
 
   @override
   void initState() {
@@ -88,6 +106,9 @@ class _ScaleTapState extends State<ScaleTap> with SingleTickerProviderStateMixin
   }
 
   Future<void> _onTapDown(_) {
+    if (_info.consumed == true) return Future.value();
+    _info.consumed = true;
+
     return anim(
       scale: widget.scaleMinValue ?? ScaleTapConfig.scaleMinValue ?? _DEFAULT_SCALE_MIN_VALUE,
       opacity: widget.opacityMinValue ?? ScaleTapConfig.opacityMinValue ?? _DEFAULT_OPACITY_MIN_VALUE,
@@ -96,6 +117,8 @@ class _ScaleTapState extends State<ScaleTap> with SingleTickerProviderStateMixin
   }
 
   Future<void> _onTapUp(_) {
+    _info.consumed = false;
+
     return anim(
       scale: 1.0,
       opacity: 1.0,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -127,20 +134,13 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Fixes #2: 'Nested ScaleTap widget animates both ScaleTap widgets'

Events were propagating from 'inner' ScaleTap to 'outer' ScaleTap widget. This made both widgets to react with touch animation. To fix this, I needed a value that could be checked by all of ScaleTap widgets in nested tree to form a source-of-truth. To do this, I created `ScaleTapInfo` class whose value can be, optionally, passed from outside. When same instance of this class is sent to all nested ScaleTap widgets, they act as if they were stitched with same thread.

I mark the tap-event as `consumed` in inner ScaleTap widget, which is later on used by parent ScaleTap widget to consume the event only if it wasn't consumed before.

The issue is fixed by default, and the developers do not need to change their code. This is because `ScaleTapInfo` has a default instance included.

If you have any queries, or feedback, please let me know.

Credit: https://stackoverflow.com/a/73481203/3682535